### PR TITLE
Protect against using colourshex when it is None

### DIFF
--- a/pydelijn/api.py
+++ b/pydelijn/api.py
@@ -181,7 +181,7 @@ class Passages:
                             resultlinecolours = await self.get_linecolours(
                                 common, ent_num, linenumber
                             )
-                            if resultlinecolours is not None:
+                            if resultlinecolours is not None and colourshex is not None:
                                 linenumcolfront = resultlinecolours.get(
                                     "voorgrond"
                                 ).get("code")


### PR DESCRIPTION
Sometimes the endpointcolors are not retrieved from the web api
```
    async def get_colourshex(self, common):
        """Get the colours hex codes."""
        if self._colourshex is None:
            endpointcolours = "{}kleuren/".format(BASE_URL)
            colourshex = {}
            resultcolours = await common.api_call(endpointcolours)
            if resultcolours is not None:
                for colours in resultcolours["kleuren"]:
                    colourshex.update({str(colours.get("code")): colours.get("hex")})
                self._colourshex = colourshex
        return self._colourshex
```
resulting in a resultcolours being None. This results in a colourshex also being None.

Add protection against None when trying to use colourshex further on in the code.